### PR TITLE
Update Lambda version to NodeJS 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Detailed instructions on testing your function can be found [in the Wiki](https:
 
 ## Build Requirements
  - [npm](https://www.npmjs.com/) ^5.6.0
- - [node](https://nodejs.org/en/) ^8.10.0
+ - [node](https://nodejs.org/en/) ^12.13.0
  - [openssl](https://www.openssl.org)
 
 ## Contributing

--- a/template.yaml
+++ b/template.yaml
@@ -8,7 +8,7 @@ Resources:
         Properties:
           CodeUri: distributions/{distribution_name}/{distribution_name}.zip
           Role: !GetAtt LambdaEdgeFunctionRole.Arn
-          Runtime: nodejs8.10
+          Runtime: nodejs12.x
           Handler: index.handler
           Timeout: 5
           AutoPublishAlias: LIVE


### PR DESCRIPTION
AWS Lambda is dropping NodeJS 8 support on December 31st, as seen [here](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).

This PR updates it to the latest LTS version.