### PR TITLE
Rewrite default urls to ./index.html

### DIFF
--- a/authn/github.index.js
+++ b/authn/github.index.js
@@ -131,7 +131,13 @@ function mainProcess(event, context, callback) {
 }
 
 function redirect(request, headers, callback) {
-  config.AUTH_REQUEST.state = request.uri;
+  var requestUri = request.uri;
+
+  if (requestUri.endsWith('/')) {
+    requestUri += "index.html";
+  }
+
+  config.AUTH_REQUEST.state = requestUri;
   // Redirect to Authorization Server
   var querystring = qs.stringify(config.AUTH_REQUEST);
 

--- a/authn/github.index.js
+++ b/authn/github.index.js
@@ -23,6 +23,20 @@ function mainProcess(event, context, callback) {
     config.AUTH_REQUEST.redirect_uri = event.Records[0].cf.config.test + config.CALLBACK_PATH;
     config.TOKEN_REQUEST.redirect_uri = event.Records[0].cf.config.test + config.CALLBACK_PATH;
   }
+
+  if (request.uri.endsWith('/')) {
+    var requestUrl = request.uri;
+
+    // Match url ending with '/' and replace with /index.html
+    var redirectUrl = requestUrl.replace(/\/$/, '\/index.html');
+
+    // Replace the received URI with the URI that includes the index page
+    request.uri = redirectUrl;
+
+    // Return to CloudFront
+    return callback(null, request);
+  }
+
   if (request.uri.startsWith(config.CALLBACK_PATH)) {
     console.log("Callback from GitHub received");
     /** Verify code is in querystring */
@@ -131,13 +145,7 @@ function mainProcess(event, context, callback) {
 }
 
 function redirect(request, headers, callback) {
-  var requestUri = request.uri;
-
-  if (requestUri.endsWith('/')) {
-    requestUri += "index.html";
-  }
-
-  config.AUTH_REQUEST.state = requestUri;
+  config.AUTH_REQUEST.state = request.uri;
   // Redirect to Authorization Server
   var querystring = qs.stringify(config.AUTH_REQUEST);
 

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -242,7 +242,14 @@ function mainProcess(event, context, callback) {
 function redirect(request, headers, callback) {
   const n = nonce.getNonce();
   config.AUTH_REQUEST.nonce = n[0];
-  config.AUTH_REQUEST.state = request.uri;
+
+  var requestUri = request.uri;
+
+  if (requestUri.endsWith('/')) {
+    requestUri += "index.html";
+  }
+
+  config.AUTH_REQUEST.state = requestUri;
 
   // Redirect to Authorization Server
   var querystring = qs.stringify(config.AUTH_REQUEST);

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -62,6 +62,20 @@ function mainProcess(event, context, callback) {
     config.AUTH_REQUEST.redirect_uri = event.Records[0].cf.config.test + config.CALLBACK_PATH;
     config.TOKEN_REQUEST.redirect_uri = event.Records[0].cf.config.test + config.CALLBACK_PATH;
   }
+
+  if (request.uri.endsWith('/')) {
+    var requestUrl = request.uri;
+
+    // Match url ending with '/' and replace with /index.html
+    var redirectUrl = requestUrl.replace(/\/$/, '\/index.html');
+
+    // Replace the received URI with the URI that includes the index page
+    request.uri = redirectUrl;
+
+    // Return to CloudFront
+    return callback(null, request);
+  }
+
   if (request.uri.startsWith(config.CALLBACK_PATH)) {
     console.log("Callback from OIDC provider received");
 
@@ -242,14 +256,7 @@ function mainProcess(event, context, callback) {
 function redirect(request, headers, callback) {
   const n = nonce.getNonce();
   config.AUTH_REQUEST.nonce = n[0];
-
-  var requestUri = request.uri;
-
-  if (requestUri.endsWith('/')) {
-    requestUri += "index.html";
-  }
-
-  config.AUTH_REQUEST.state = requestUri;
+  config.AUTH_REQUEST.state = request.uri;
 
   // Redirect to Authorization Server
   var querystring = qs.stringify(config.AUTH_REQUEST);

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -251,7 +251,14 @@ function redirect(request, headers, callback) {
   config.AUTH_REQUEST.code_challenge=challenge[1];
   config.AUTH_REQUEST.code_challenge_method="S256"
   config.AUTH_REQUEST.nonce = n[0];
-  config.AUTH_REQUEST.state = request.uri;
+
+  var requestUri = request.uri;
+
+  if (requestUri.endsWith('/')) {
+    requestUri += "index.html";
+  }
+
+  config.AUTH_REQUEST.state = requestUri;
 
   // Redirect to Authorization Server
   var querystring = qs.stringify(config.AUTH_REQUEST);

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -63,6 +63,20 @@ function mainProcess(event, context, callback) {
     config.AUTH_REQUEST.redirect_uri = event.Records[0].cf.config.test + config.CALLBACK_PATH;
     config.TOKEN_REQUEST.redirect_uri = event.Records[0].cf.config.test + config.CALLBACK_PATH;
   }
+
+  if (request.uri.endsWith('/')) {
+    var requestUrl = request.uri;
+
+    // Match url ending with '/' and replace with /index.html
+    var redirectUrl = requestUrl.replace(/\/$/, '\/index.html');
+
+    // Replace the received URI with the URI that includes the index page
+    request.uri = redirectUrl;
+
+    // Return to CloudFront
+    return callback(null, request);
+  }
+
   if (request.uri.startsWith(config.CALLBACK_PATH)) {
     console.log("Callback from OIDC provider received");
 
@@ -251,14 +265,7 @@ function redirect(request, headers, callback) {
   config.AUTH_REQUEST.code_challenge=challenge[1];
   config.AUTH_REQUEST.code_challenge_method="S256"
   config.AUTH_REQUEST.nonce = n[0];
-
-  var requestUri = request.uri;
-
-  if (requestUri.endsWith('/')) {
-    requestUri += "index.html";
-  }
-
-  config.AUTH_REQUEST.state = requestUri;
+  config.AUTH_REQUEST.state = request.uri;
 
   // Redirect to Authorization Server
   var querystring = qs.stringify(config.AUTH_REQUEST);


### PR DESCRIPTION
Since we need to use a `CloudFrontOriginAccessIdentity` to not expose our S3 content publicly, we can't (I believe) use the S3 website endpoint as a CloudFront origin, meaning we can't use the S3 website feature which allows for default folder URLs to resolve to `index.html` under the hood. This PR rewrites all URI's which end in '/' to append 'index.html'.

It might be nice to make this configurable; I'm willing to go down the road of updating the `build.js` to add that as a parameter if folks think this is useful enough.