### PR TITLE
Parse `%20` as spaces before printing them

### DIFF
--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -294,8 +294,8 @@ function unauthorized(error, error_description, error_uri, callback) {
   </html>
   `;
 
-  page = page.replace(/%error%/g, encodeURI(error));
-  page = page.replace(/%error_description%/g, encodeURI(error_description));
+  page = page.replace(/%error%/g, encodeURI(error).replace(/%20/g,' '));
+  page = page.replace(/%error_description%/g, encodeURI(error_description).replace(/%20/g,' '));
   page = page.replace(/%error_uri%/g, encodeURI(error_uri));
 
   // Unauthorized access attempt. Reset token and nonce cookies


### PR DESCRIPTION
Didn't realise I forgot to add this to my last PR, sorry.

Right now errors or descriptions with spaces would print them out as `Access%20Denied` for example.
We want the `%20` to actually be a space in the end.