### PR TITLE
Allow google group members on different domains

### DIFF
--- a/authz/google.groups-lookup.js
+++ b/authz/google.groups-lookup.js
@@ -24,12 +24,12 @@ function isAuthorized(decoded, request, callback, unauthorized, internalServerEr
     .then(function(response) {
       for (var i = 0; i < googleAuthz.cloudfront_authz_groups.length; i++) {
         var authorization = response.data.token_type + ' ' + response.data.access_token;
-        var membershipGet = 'https://www.googleapis.com/admin/directory/v1/groups/' + googleAuthz.cloudfront_authz_groups[i] + '/hasMember/' + decoded.sub;
+        var membershipGet = 'https://www.googleapis.com/admin/directory/v1/groups/' + googleAuthz.cloudfront_authz_groups[i] + '/members/' + decoded.sub;
         console.log(membershipGet + ': ' + authorization);
         axios.get(membershipGet, { headers: {'Authorization': authorization}})
           .then(function(response) {
             groupChecks++;
-            if (!response.data.error && response.data.isMember == true && decoded.aud === request.headers.host[0].value && decoded.sub.endsWith(config.HOSTED_DOMAIN)) {
+            if (!response.data.error && response.data.status === 'ACTIVE' && decoded.aud === request.headers.host[0].value) {
               callback(null, request);
             } else if (groupChecks >= googleAuthz.cloudfront_authz_groups.length) {
               unauthorized('Unauthorized', 'User ' + decoded.sub + ' is not permitted.', '', callback);


### PR DESCRIPTION
This resolves https://github.com/Widen/cloudfront-auth/issues/52 by making the following two changes:

- use the [Get Members](https://developers.google.com/admin-sdk/directory/v1/reference/members/get?authuser=1) Google Directory API call instead of hasMembers, which has [this bug](https://issuetracker.google.com/issues/109861216).
- remove the constraint, that the user in the group must be a member of the HOST_DOMAIN. The assumpion is, when using a group for authorization, non-members of the host domain are permitted.