### PR TITLE
Add support for Azure AD custom signing keys in build.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Session duration is defined as the number of hours that the JWT is valid for. Af
     1. Once created, go to your application `Settings -> Keys` and make a new key with your desired duration. Click save and copy the value. This will be your `client_secret`
     1. Above where you selected `Keys`, go to `Reply URLs` and enter your Cloudfront hostname with your preferred path value for the authorization callback. Example: https://my-cloudfront-site.example.com/_callback
 1. Execute `./build.sh` in the downloaded directory. NPM will run to download dependencies and a RSA key will be generated.
-1. Choose `Microsoft` as the authorization method and enter the values for [Tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-howto-tenant), Client ID (**Application ID**), Client Secret (**previously created key**), Redirect URI and Session Duration
+1. Choose `Microsoft` as the authorization method and enter the values for [Tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-howto-tenant), Client ID (**Application ID**), Client Secret (**previously created key**), Redirect URI, whether your application has [custom signing keys](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#fetch-the-openid-connect-metadata-document) and Session Duration
 1. Select the preferred authentication method
     1. Azure AD Membership (default)
     1. JSON Username Lookup

--- a/build/build.js
+++ b/build/build.js
@@ -112,6 +112,13 @@ function microsoftConfiguration() {
         required: true,
         default: R.pathOr('', ['AUTH_REQUEST', 'redirect_uri'], oldConfig)
       },
+      CUSTOM_SIGNING_KEYS: {
+        description: colors.red("Use custom signing keys\n  (1) No\n   (2) Yes"),
+        pattern: /^[1-2]$/,
+        message: colors.red("Please choose:\n   (1) No\n   (2) Yes"),
+        required: true,
+        default: R.pathOr('', ['CUSTOM_SIGNING_KEYS'], oldConfig)
+      },
       SESSION_DURATION: {
         message: colors.red("Session Duration (hours)"),
         required: true,
@@ -125,7 +132,9 @@ function microsoftConfiguration() {
     config.PRIVATE_KEY = fs.readFileSync('distributions/' + config.DISTRIBUTION + '/id_rsa', 'utf8');
     config.PUBLIC_KEY = fs.readFileSync('distributions/' + config.DISTRIBUTION + '/id_rsa.pub', 'utf8');
     config.TENANT = result.TENANT;
-    config.DISCOVERY_DOCUMENT = 'https://login.microsoftonline.com/' + result.TENANT + '/.well-known/openid-configuration';
+    config.DISCOVERY_DOCUMENT = result.CUSTOM_SIGNING_KEYS === '1'
+      ? `https://login.microsoftonline.com/${result.TENANT}/.well-known/openid-configuration`
+      : `https://login.microsoftonline.com/${result.TENANT}/.well-known/openid-configuration?appid=${result.CLIENT_ID}`;
     config.SESSION_DURATION = parseInt(result.SESSION_DURATION, 10) * 60 * 60;
 
     config.CALLBACK_PATH = url.parse(result.REDIRECT_URI).pathname;


### PR DESCRIPTION
If user chooses to use custom signing keys, query parameter "appid" with value of CLIENT_ID is appended to the discovery document URL.

This pull request resolves issue #85.